### PR TITLE
Fix PinFieldAutoFill dispose

### DIFF
--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -112,8 +112,8 @@ class _PinFieldAutoFillState extends State<PinFieldAutoFill> with CodeAutoFill {
   void dispose() {
     cancel();
     if (!controller.autoDispose) {
-	  controller.dispose();
-	}
+      controller.dispose();
+    }
     super.dispose();
   }
 }

--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -111,7 +111,9 @@ class _PinFieldAutoFillState extends State<PinFieldAutoFill> with CodeAutoFill {
   @override
   void dispose() {
     cancel();
-    controller.dispose();
+    if (!controller.autoDispose) {
+	  controller.dispose();
+	}
     super.dispose();
   }
 }


### PR DESCRIPTION
So it does not throw error trying to dispose already disposed PinEditingController