### PR TITLE
Updating phone hint request code to work with fragment.

### DIFF
--- a/android/src/main/java/com/jaumard/smsautofill/SmsAutoFillPlugin.java
+++ b/android/src/main/java/com/jaumard/smsautofill/SmsAutoFillPlugin.java
@@ -40,7 +40,7 @@ import com.jaumard.smsautofill.AppSignatureHelper;
  * SmsAutoFillPlugin
  */
 public class SmsAutoFillPlugin implements MethodCallHandler {
-    private static final int PHONE_HINT_REQUEST = 101012;
+    private static final int PHONE_HINT_REQUEST = 11012;
 
     private Activity activity;
     private Result pendingHintResult;


### PR DESCRIPTION
Since an activity which starts from fragment(not activity), request code should be in 0 ~ 65535.

This prevents error throwing when extending FlutterFragmentActivity rather than FlutterActivity for MainActivity and requesting phone number hint.