### PR TITLE
Trigger onCodeChanged on autofill

### DIFF
--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -116,6 +116,9 @@ class _PinFieldAutoFillState extends State<PinFieldAutoFill> with CodeAutoFill {
   @override
   void codeUpdated() {
     controller.value = TextEditingValue(text: code ?? '');
+    if (widget.onCodeChanged != null) {
+      widget.onCodeChanged(code ?? '');
+    }
   }
 
   @override
@@ -277,6 +280,9 @@ class _TextFieldPinAutoFillState extends State<TextFieldPinAutoFill> with CodeAu
   @override
   void codeUpdated() {
     _textController.value = TextEditingValue(text: code ?? '');
+    if (widget.onCodeChanged != null) {
+      widget.onCodeChanged(code ?? '');
+    }
   }
 
   @override


### PR DESCRIPTION
I think it would make sense if the widgets called `onCodeChanged` also when the input changes due to the autofill mechanism. This enables the UI to proceed immediately when the SMS is received, instead of requiring the user to tap "done" manually.