### PR TITLE
#48: Update dependencies to solve deprecation API warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-auth:17.0.0'
-    implementation 'androidx.core:core:1.1.0'
+    implementation 'com.google.android.gms:play-services-auth:18.1.0'
+    implementation 'androidx.core:core:1.3.2'
 }


### PR DESCRIPTION
I think dependencies lib use deprecation APIs.
After I update dependencies, I never see the deprecation API warning.