### PR TITLE
PhoneFieldHintState fix when using an external controller or focus node

### DIFF
--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -178,11 +178,13 @@ class _PhoneFieldHintState extends State<PhoneFieldHint> {
   TextEditingController _controller;
   FocusNode _focusNode;
   bool _hintShown = false;
+  bool _isUsingInternalController = false;
+  bool _isUsingInternalFocusNode = false;
 
   @override
   void initState() {
-    _controller = widget.controller ?? widget.child?.controller ?? TextEditingController(text: '');
-    _focusNode = widget.focusNode ?? widget.child?.focusNode ?? FocusNode();
+    _controller = widget.controller ?? widget.child?.controller ?? _createInternalController();
+    _focusNode = widget.focusNode ?? widget.child?.focusNode ?? _createInternalFocusNode();
     _focusNode.addListener(() async {
       if (_focusNode.hasFocus && !_hintShown) {
         _hintShown = true;
@@ -218,14 +220,29 @@ class _PhoneFieldHintState extends State<PhoneFieldHint> {
 
   @override
   void dispose() {
-    _controller.dispose();
-    _focusNode.dispose();
+    if(_isUsingInternalController) {
+      _controller.dispose();
+    }
+
+    if(_isUsingInternalFocusNode) {
+      _focusNode.dispose();
+    }
     super.dispose();
   }
 
   Future<void> _askPhoneHint() async {
     String hint = await _autoFill.hint;
     _controller.value = TextEditingValue(text: hint ?? '');
+  }
+
+  TextEditingController _createInternalController() {
+    _isUsingInternalController = true;
+    return TextEditingController(text: '');
+  }
+
+  FocusNode _createInternalFocusNode() {
+    _isUsingInternalFocusNode = true;
+    return FocusNode();
   }
 }
 


### PR DESCRIPTION
When using an external controller with PhoneFieldHint during dispose the controller is disposed of by PhoneFieldHint, which can lead to undesirable behaviour.

The fix here is to only dispose when the controller has been created internally by the widget.

I discovered this problem when using Flutter Hooks and I kept getting an error from the hooks library that it could not deal with a controller it provided as it had already been disposed. 