### PR TITLE
Allow for validation of the field via TextFormWidget

### DIFF
--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -158,6 +158,8 @@ class PhoneFieldHint extends StatefulWidget {
   final FocusNode focusNode;
   final TextEditingController controller;
   final List<TextInputFormatter> inputFormatters;
+  final FormFieldValidator validator;
+  final bool isFormWidget;
   final InputDecoration decoration;
   final TextField child;
 
@@ -166,6 +168,8 @@ class PhoneFieldHint extends StatefulWidget {
     this.child,
     this.controller,
     this.inputFormatters,
+    this.validator,
+    this.isFormWidget,
     this.decoration,
     this.autofocus = false,
     this.focusNode,
@@ -217,16 +221,7 @@ class _PhoneFieldHintState extends State<PhoneFieldHint> {
       ) : null,
     );
 
-    return widget.child ??
-        TextField(
-          autofocus: widget.autofocus,
-          focusNode: _focusNode,
-          autofillHints: [AutofillHints.telephoneNumber],
-          inputFormatters: _inputFormatters,
-          decoration: decoration,
-          controller: _controller,
-          keyboardType: TextInputType.phone,
-        );
+    return widget.child ?? _createField(widget.isFormWidget, decoration, widget.validator);
   }
 
   @override
@@ -239,6 +234,37 @@ class _PhoneFieldHintState extends State<PhoneFieldHint> {
       _focusNode.dispose();
     }
     super.dispose();
+  }
+
+  Widget _createField(bool isFormWidget, InputDecoration decoration, FormFieldValidator validator) {
+    return isFormWidget
+        ? _createTextFormField(decoration, validator)
+        : _createTextField(decoration);
+  }
+
+  Widget _createTextField(InputDecoration decoration) {
+    return TextField(
+      autofocus: widget.autofocus,
+      focusNode: _focusNode,
+      autofillHints: [AutofillHints.telephoneNumber],
+      inputFormatters: _inputFormatters,
+      decoration: decoration,
+      controller: _controller,
+      keyboardType: TextInputType.phone,
+    );
+  }
+
+  Widget _createTextFormField(InputDecoration decoration, FormFieldValidator validator) {
+    return TextFormField(
+      validator: validator,
+      autofocus: widget.autofocus,
+      focusNode: _focusNode,
+      autofillHints: [AutofillHints.telephoneNumber],
+      inputFormatters: _inputFormatters,
+      decoration: decoration,
+      controller: _controller,
+      keyboardType: TextInputType.phone,
+    );
   }
 
   Future<void> _askPhoneHint() async {

--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -169,7 +169,7 @@ class PhoneFieldHint extends StatefulWidget {
     this.controller,
     this.inputFormatters,
     this.validator,
-    this.isFormWidget,
+    this.isFormWidget = false,
     this.decoration,
     this.autofocus = false,
     this.focusNode,

--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -153,7 +153,70 @@ class _PinFieldAutoFillState extends State<PinFieldAutoFill> with CodeAutoFill {
   }
 }
 
-class PhoneFieldHint extends StatefulWidget {
+class PhoneFormFieldHint extends StatelessWidget {
+  final bool autofocus;
+  final FocusNode focusNode;
+  final TextEditingController controller;
+  final List<TextInputFormatter> inputFormatters;
+  final FormFieldValidator validator;
+  final InputDecoration decoration;
+  final TextField child;
+
+  const PhoneFormFieldHint({
+    Key key,
+    this.child,
+    this.controller,
+    this.inputFormatters,
+    this.validator,
+    this.decoration,
+    this.autofocus = false,
+    this.focusNode,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _PhoneFieldHint(key: key,
+        child: child,
+        inputFormatters: inputFormatters,
+        validator: validator,
+        decoration: decoration,
+        autofocus: autofocus,
+        focusNode: focusNode,
+        isFormWidget: true);
+  }
+}
+
+class PhoneFieldHint extends StatelessWidget {
+  final bool autofocus;
+  final FocusNode focusNode;
+  final TextEditingController controller;
+  final List<TextInputFormatter> inputFormatters;
+  final InputDecoration decoration;
+  final TextField child;
+
+  const PhoneFieldHint({
+    Key key,
+    this.child,
+    this.controller,
+    this.inputFormatters,
+    this.decoration,
+    this.autofocus = false,
+    this.focusNode,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _PhoneFieldHint(key: key,
+        child: child,
+        inputFormatters: inputFormatters,
+        decoration: decoration,
+        autofocus: autofocus,
+        focusNode: focusNode,
+        isFormWidget: false);
+  }
+}
+
+class _PhoneFieldHint extends StatefulWidget {
   final bool autofocus;
   final FocusNode focusNode;
   final TextEditingController controller;
@@ -163,7 +226,7 @@ class PhoneFieldHint extends StatefulWidget {
   final InputDecoration decoration;
   final TextField child;
 
-  const PhoneFieldHint({
+  const _PhoneFieldHint({
     Key key,
     this.child,
     this.controller,
@@ -181,7 +244,7 @@ class PhoneFieldHint extends StatefulWidget {
   }
 }
 
-class _PhoneFieldHintState extends State<PhoneFieldHint> {
+class _PhoneFieldHintState extends State<_PhoneFieldHint> {
   final SmsAutoFill _autoFill = SmsAutoFill();
   TextEditingController _controller;
   List<TextInputFormatter> _inputFormatters;


### PR DESCRIPTION
This PR allows for validation to be performed on the field. There are several use cases:

- Manual entry of the field needs to be validated as part of a form e.g. the field it empty.

- The provided phone number while valid is not one the application is looking for. e.g. wrong country code.