### PR TITLE
Fix null error

### DIFF
--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -26,8 +26,8 @@ class SmsAutoFill {
 
   Stream<String> get code => _code.stream;
 
-  Future<String> get hint async {
-    final String version = await _channel.invokeMethod('requestPhoneHint');
+  Future<String?> get hint async {
+    final String? version = await _channel.invokeMethod('requestPhoneHint');
     return version;
   }
 


### PR DESCRIPTION
FIx error when user is not choosing any phone number.

`type 'Null' is not a subtype of type 'String'`