### PR TITLE
Updated documentation about currentCode null vs empty

### DIFF
--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -116,7 +116,6 @@ class _PinFieldAutoFillState extends State<PinFieldAutoFill> with CodeAutoFill {
     _shouldDisposeController = widget.controller == null;
     controller = widget.controller ?? TextEditingController(text: '');
     code = widget.currentCode;
-    codeUpdated();
     controller.addListener(() {
       if (controller.text != code) {
         code = controller.text;


### PR DESCRIPTION
Follows using setState({}) inside onCodeChanged resulting in build error if currentCode is null rather than just empty.

Code in question: https://github.com/jaumard/sms_autofill/blob/master/lib/sms_autofill.dart#L119