### PR TITLE
Fix call to `listenForCode` in `example`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Just before you sent your phone number to the backend, you need to let the plugi
 To do that you need to do:
 
 ```dart
-await SmsAutoFill().listenForCode;
+await SmsAutoFill().listenForCode();
 ```
 This will listen for the SMS with the code during 5 minutes and when received, autofill the following widget.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,7 +72,7 @@ class _HomePageState extends State<HomePage> {
               ElevatedButton(
                 child: Text('Listen for sms code'),
                 onPressed: () async {
-                  await SmsAutoFill().listenForCode;
+                  await SmsAutoFill().listenForCode();
                 },
               ),
               ElevatedButton(


### PR DESCRIPTION
The `listenForCode` is a function and not a future, and there is a warning that:

> 'await' applied to 'Future<void> Function({String smsCodeRegexPattern})', which is not a 'Future'. ([lint](https://dart-lang.github.io/linter/lints/await_only_futures.html))