### PR TITLE
Remove caps in pubspec for pin_input_text_field package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,19 +7,26 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -33,26 +40,19 @@ packages:
       name: pin_input_text_field
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
+    version: "4.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.22.0"
 
 dependencies:
-  pin_input_text_field: ^4.1.1
+  pin_input_text_field: 4.2.0
     #git:
     #  url: https://github.com/TinoGuo/pin_input_text_field
     #  ref: dev


### PR DESCRIPTION
# Context

Recently `pin_input_text_field` was updated to the `4.3.0` version and this repository was broken. 

https://pub.dev/packages/pin_input_text_field/versions/4.3.0

# Description

This PR removes caps in `pubspec.yaml` and makes the library more stable in the future.
