### PR TITLE
Removes references to Flutter v1 android embedding classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+* Removes references to Flutter v1 android embedding classes.
+
 ## 2.4.0
 
 * Fix android 14 crash

--- a/android/src/main/java/com/jaumard/smsautofill/SmsAutoFillPlugin.java
+++ b/android/src/main/java/com/jaumard/smsautofill/SmsAutoFillPlugin.java
@@ -40,7 +40,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * SmsAutoFillPlugin
@@ -79,21 +78,8 @@ public class SmsAutoFillPlugin implements FlutterPlugin, ActivityAware, MethodCa
     public SmsAutoFillPlugin() {
     }
 
-    private SmsAutoFillPlugin(Registrar registrar) {
-        activity = registrar.activity();
-        setupChannel(registrar.messenger());
-        registrar.addActivityResultListener(activityResultListener);
-    }
-
     public void setCode(String code) {
         channel.invokeMethod("smscode", code);
-    }
-
-    /**
-     * Plugin registration.
-     */
-    public static void registerWith(Registrar registrar) {
-        new SmsAutoFillPlugin(registrar);
     }
 
     @Override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sms_autofill
 description: Flutter plugin to provide SMS code autofill support
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/jaumard/sms_autofill
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/jaumard/sms_autofill/issues/240.

Tested by building a copy of the sms_autofill example app with the changes in https://github.com/flutter/engine/pull/52022 applied. 
