### PR TITLE
Added `Styles` support to `PhoneFieldHint`

### DIFF
--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -238,6 +238,7 @@ class PhoneFieldHint extends StatelessWidget {
   final List<TextInputFormatter>? inputFormatters;
   final InputDecoration? decoration;
   final TextField? child;
+  final TextStyle? style;
 
   const PhoneFieldHint({
     Key? key,
@@ -247,6 +248,7 @@ class PhoneFieldHint extends StatelessWidget {
     this.decoration,
     this.autoFocus = false,
     this.focusNode,
+    this.style,
   }) : super(key: key);
 
   @override
@@ -259,6 +261,7 @@ class PhoneFieldHint extends StatelessWidget {
         decoration: decoration,
         autoFocus: autoFocus,
         focusNode: focusNode,
+        style: style,
         isFormWidget: false);
   }
 }
@@ -272,6 +275,7 @@ class _PhoneFieldHint extends StatefulWidget {
   final bool isFormWidget;
   final InputDecoration? decoration;
   final TextField? child;
+  final TextStyle? style;
 
   const _PhoneFieldHint({
     Key? key,
@@ -284,6 +288,7 @@ class _PhoneFieldHint extends StatefulWidget {
     this.autoFocus = false,
     this.enabled = true,
     this.focusNode,
+    this.style,
   }) : super(key: key);
 
   @override
@@ -319,7 +324,6 @@ class _PhoneFieldHintState extends State<_PhoneFieldHint> {
         });
       }
     });
-
     super.initState();
   }
 
@@ -371,6 +375,7 @@ class _PhoneFieldHintState extends State<_PhoneFieldHint> {
       decoration: decoration,
       controller: _controller,
       keyboardType: TextInputType.phone,
+      style: widget.style,
     );
   }
 
@@ -386,6 +391,7 @@ class _PhoneFieldHintState extends State<_PhoneFieldHint> {
       decoration: decoration,
       controller: _controller,
       keyboardType: TextInputType.phone,
+      style: widget.style,
     );
   }
 

--- a/lib/sms_autofill.dart
+++ b/lib/sms_autofill.dart
@@ -202,6 +202,7 @@ class PhoneFormFieldHint extends StatelessWidget {
   final FormFieldValidator? validator;
   final InputDecoration? decoration;
   final TextField? child;
+  final TextStyle? style;
 
   const PhoneFormFieldHint({
     Key? key,
@@ -213,6 +214,7 @@ class PhoneFormFieldHint extends StatelessWidget {
     this.autoFocus = false,
     this.enabled = true,
     this.focusNode,
+    this.style,
   }) : super(key: key);
 
   @override
@@ -227,7 +229,8 @@ class PhoneFormFieldHint extends StatelessWidget {
         autoFocus: autoFocus,
         enabled: enabled,
         focusNode: focusNode,
-        isFormWidget: true);
+        isFormWidget: true,
+        style: style);
   }
 }
 


### PR DESCRIPTION
Currently, the `PhoneFieldHint` widget only exposes `decoration` for customizing the `TextField`. This allows us to change placeholder/hint styling, but not the style of the actual user-entered text.

This is problematic in apps with dark themes:
- The placeholder (hintText) can be styled white,
- But the typed text still defaults to black, making it invisible against a dark background,

The workaround today is to supply a custom child: `TextField`, but doing so disables the automatic hint picker behavior of `PhoneFieldHint`, which defeats the purpose of using this widget.


This PR Adds an optional parameter to `PhoneFieldHint`:
- `TextStyle? style` → controls the `style` of the entered text
